### PR TITLE
Fix PrintFrame() causing segfault

### DIFF
--- a/examples/xbeetest.cpp
+++ b/examples/xbeetest.cpp
@@ -236,6 +236,10 @@ int TestByteSum() {
     return 0;
 }
 
+void CallbackFunction(XBEE::Frame *item) {
+
+}
+
 int main(int argc, char* argv[]) {
     if (TestHexString()) cout << "HexString test failed" << std::endl;
     if (TestByteSum()) cout << "ByteSum test failed" << std::endl;
@@ -244,18 +248,21 @@ int main(int argc, char* argv[]) {
     XBEE::SerialXbee test;
     // Wrap in a try/catch block for error checking
     test.Connect();
-    /*
-    XBEE::TransmitRequest frame_0(0x0013A20040A815D6);
-    frame_0.SetData("Hello QuadD!");
-    */
-    test.AsyncReadFrame();
+    test.ReadHandler = std::bind(&CallbackFunction, std::placeholders::_1);
+    
+    // 0x0013A20040A815D6
+    XBEE::TransmitRequest frame_0(0x0013A200409BD79C);
+    frame_0.SetData("NEWMSG,UPDT,Q2,P35.300266 -120.661823 101.653000,SOnline,R0");
+
+    //test.AsyncReadFrame();
     int i = 0;
 
     while(true) {
+        XBEE::TransmitRequest frame_0(0x0013A200409BD79C);
+        frame_0.SetData("NEWMSG,UPDT,Q2,P35.300266 -120.661823 101.653000,SOnline,R0");
+
         std::cout << std::dec << i++ << " seconds have passed" << std::endl;
-        /*if (i == 5 || i == 6) {
-            test.AsyncWriteFrame(&frame_0);
-        }*/
+        test.AsyncWriteFrame(&frame_0);
         sleep(1);
     }
 }

--- a/src/ReceivePacket.cpp
+++ b/src/ReceivePacket.cpp
@@ -72,6 +72,7 @@ namespace XBEE {
   }
 
   std::string ReceivePacket::ToHexString(HexFormat spacing) const {
+
         std::stringstream tmp;
     // TODO: Implement HexString function without third argument
       bool even_space = false;

--- a/src/SerialXbee.cpp
+++ b/src/SerialXbee.cpp
@@ -154,7 +154,7 @@ namespace XBEE {
 	}
 
 	void SerialXbee::PrintFrame(Frame *a_frame) {
-		std::cout << a_frame->ToHexString(HexFormat::BYTE_SPACING) << std::endl;
+		//std::cout << a_frame->ToHexString(HexFormat::BYTE_SPACING) << std::endl;
 	}
 
 	void SerialXbee::AsyncReadFrame() {
@@ -163,6 +163,7 @@ namespace XBEE {
 	}
 
 	void SerialXbee::AsyncWriteFrame(Frame *a_frame) {
+		std::cerr << "AUFPEAUIPFOEIAUPOFIEJA\n";
 		std::vector<uint8_t> temp = a_frame->SerializeFrame();
 		boost::asio::async_write(port, boost::asio::buffer(temp, temp.size()), boost::bind(&SerialXbee::FrameWritten, this, _1, _2, a_frame));
 	}

--- a/src/SerialXbee.cpp
+++ b/src/SerialXbee.cpp
@@ -163,7 +163,6 @@ namespace XBEE {
 	}
 
 	void SerialXbee::AsyncWriteFrame(Frame *a_frame) {
-		std::cerr << "AUFPEAUIPFOEIAUPOFIEJA\n";
 		std::vector<uint8_t> temp = a_frame->SerializeFrame();
 		boost::asio::async_write(port, boost::asio::buffer(temp, temp.size()), boost::bind(&SerialXbee::FrameWritten, this, _1, _2, a_frame));
 	}


### PR DESCRIPTION
Running MAQSS segfaults at unpredictable times when trying to send a message. Not printing the frame as a hex string solves this issue.

This is a band-aid solution. When rewriting this library, we will need to make sure that our solution for printing the frame as a hex string is robust and bug-free.