### PR TITLE
Buffer overflow fix

### DIFF
--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -24,7 +24,7 @@ namespace XBEE {
         std::string std_str(value);
         uint16_t ndx;
         uint16_t len = std_str.length();
-        char str_buf[len];
+        char str_buf[3]; // const 3 byte size (2 hex chars + null terminator)
         std::stringstream stream; // declare a stringstream to store the hex octets
 
         // loop through length of char array/std::string
@@ -56,7 +56,7 @@ namespace XBEE {
         std::string std_str(value);
         uint16_t ndx;
         uint16_t len = std_str.length();
-        char str_buf[len];
+        char str_buf[3]; // const 3 byte size (2 hex chars + null terminator)
         std::stringstream stream; // declare a stringstream to store the hex octets
 
         // loop through length of char array/std::string

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -84,7 +84,7 @@ namespace XBEE {
          */
         uint16_t ndx;
         uint16_t len = value.length();
-        char str_buf[len];
+        char str_buf[3]; // const 3 byte size (2 hex chars + null terminator)
         std::stringstream stream; // declare a stringstream to store the hex octets
 
         // loop through length of std::string
@@ -116,7 +116,7 @@ namespace XBEE {
         uint16_t ndx;
         uint16_t dataNdx;
         uint16_t len = sizeof (value);
-        char str_buf[len];
+        char str_buf[3]; // const 3 byte size (2 hex chars + null terminator)
         uint8_t *dat = (uint8_t*) & value; // declare a stringstream to store the hex octets
         std::stringstream stream; // declare a stringstream to store the hex octets
 


### PR DESCRIPTION
Fixed an issue where the character buffer was either larger than necessary, or too small (potentially causing buffer overflows).